### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,41 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
-    target-branch: "dev"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
+    commit-message:
+      prefix: "deps(maven)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    target-branch: "dev"
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
+    commit-message:
+      prefix: "deps(github-actions)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Standardizes the Dependabot configuration for this repository to match the tribly reference standard:

- **maven** (`/`): weekly on Monday at 09:00 Europe/Paris, limit 5 PRs
- **github-actions** (`/`): weekly on Monday at 10:00 Europe/Paris, limit 5 PRs

All ecosystems are configured with:
- Weekly grouped minor+patch updates
- Assignee: glandais
- Scoped commit message prefixes (`deps(<ecosystem>)`)
- Label: `dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)