### PR TITLE
fix: GPX writer emitted invalid XML that the reader could not read back

### DIFF
--- a/gpx/src/main/java/io/github/glandais/gpx/io/read/GPXFileReader.java
+++ b/gpx/src/main/java/io/github/glandais/gpx/io/read/GPXFileReader.java
@@ -3,12 +3,14 @@ package io.github.glandais.gpx.io.read;
 import io.github.glandais.gpx.data.*;
 import io.github.glandais.gpx.io.GPXField;
 import jakarta.inject.Singleton;
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -19,6 +21,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 @Service
 @Singleton
@@ -32,13 +35,7 @@ public class GPXFileReader {
     }
 
     public GPX parseGPX(InputStream is, String forcedName, boolean erasePathNames) throws Exception {
-        return parseGPX(is, forcedName, erasePathNames, (db, f) -> {
-            try {
-                return db.parse(f);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        return parseGPX(is.readAllBytes(), forcedName, erasePathNames, "input stream");
     }
 
     public GPX parseGPX(File file) throws Exception {
@@ -46,20 +43,39 @@ public class GPXFileReader {
     }
 
     public GPX parseGPX(File file, String forcedName, boolean erasePathNames) throws Exception {
-        return parseGPX(file, forcedName, erasePathNames, (db, f) -> {
-            try {
-                return db.parse(f);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        return parseGPX(Files.readAllBytes(file.toPath()), forcedName, erasePathNames, file.getPath());
     }
 
-    private <T> GPX parseGPX(
-            T file, String forcedName, boolean erasePathNames, BiFunction<DocumentBuilder, T, Document> parser)
-            throws Exception {
-        DocumentBuilder db = newSecureDocumentBuilder();
-        Document gpxDocument = parser.apply(db, file);
+    /**
+     * Parses strictly first. Only when that fails on malformed XML do we retry once on repaired
+     * bytes, through the same hardened builder. Surviving repair grants no extra trust: a DOCTYPE is
+     * still refused on the second pass. When repair does not help, the original error is what the
+     * caller sees.
+     */
+    private GPX parseGPX(byte[] raw, String forcedName, boolean erasePathNames, String source) throws Exception {
+        Document gpxDocument;
+        try {
+            gpxDocument = parseDocument(raw);
+        } catch (SAXException | IOException strictFailure) {
+            byte[] repaired = GpxXmlRepair.repair(raw);
+            if (repaired == null) {
+                throw strictFailure;
+            }
+            try {
+                gpxDocument = parseDocument(repaired);
+            } catch (SAXException | IOException repairFailure) {
+                throw strictFailure;
+            }
+            log.warn("Repaired malformed XML in {}: {}", source, strictFailure.getMessage());
+        }
+        return toGPX(gpxDocument, forcedName, erasePathNames);
+    }
+
+    private Document parseDocument(byte[] raw) throws ParserConfigurationException, SAXException, IOException {
+        return newSecureDocumentBuilder().parse(new ByteArrayInputStream(raw));
+    }
+
+    private GPX toGPX(Document gpxDocument, String forcedName, boolean erasePathNames) {
         String gpxName;
         if (forcedName != null) {
             gpxName = forcedName;

--- a/gpx/src/main/java/io/github/glandais/gpx/io/read/GpxXmlRepair.java
+++ b/gpx/src/main/java/io/github/glandais/gpx/io/read/GpxXmlRepair.java
@@ -1,0 +1,131 @@
+package io.github.glandais.gpx.io.read;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Repairs the two ways real GPX files are malformed that can be fixed without guessing: text
+ * encoded in ISO-8859-1 but declared (or assumed) UTF-8, and astral characters written as a pair of
+ * numeric references to UTF-16 surrogate code points, which XML 1.0 forbids.
+ *
+ * <p>Never touches the DOCTYPE, so a repaired document is no more trusted than the original.
+ */
+final class GpxXmlRepair {
+
+    private GpxXmlRepair() {}
+
+    /** A single numeric character reference, decimal (group 1) or hexadecimal (group 2). */
+    private static final Pattern NUMERIC_REFERENCE = Pattern.compile("&#(?:([0-9]+)|[xX]([0-9a-fA-F]+));");
+
+    private static final Pattern DECLARED_ENCODING =
+            Pattern.compile("(<\\?xml[^>]*?encoding\\s*=\\s*[\"'])([^\"']*)([\"'])");
+
+    /**
+     * @return repaired bytes, or null when there was nothing to repair
+     */
+    static byte[] repair(byte[] raw) {
+        boolean reEncoded = false;
+        String text;
+        if (isValidUtf8(raw)) {
+            text = new String(raw, StandardCharsets.UTF_8);
+        } else {
+            text = forceUtf8Declaration(new String(raw, StandardCharsets.ISO_8859_1));
+            reEncoded = true;
+        }
+
+        String recombined = recombineSurrogatePairs(text);
+        if (!reEncoded && recombined.equals(text)) {
+            return null;
+        }
+        return recombined.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static boolean isValidUtf8(byte[] raw) {
+        CharsetDecoder decoder = StandardCharsets.UTF_8
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        try {
+            decoder.decode(ByteBuffer.wrap(raw));
+            return true;
+        } catch (CharacterCodingException e) {
+            return false;
+        }
+    }
+
+    /** After re-encoding to UTF-8, a stale encoding declaration would make the parser misread us. */
+    private static String forceUtf8Declaration(String xml) {
+        if (!xml.startsWith("<?xml")) {
+            return xml;
+        }
+        Matcher matcher = DECLARED_ENCODING.matcher(xml);
+        if (!matcher.find()) {
+            return xml;
+        }
+        return xml.substring(0, matcher.start())
+                + matcher.group(1)
+                + "UTF-8"
+                + matcher.group(3)
+                + xml.substring(matcher.end());
+    }
+
+    /**
+     * Scans references one by one rather than matching pairs directly: a pattern consuming two
+     * references at once would swallow the high surrogate of the real pair in
+     * {@code &#65;&#55358;&#56600;} and miss it.
+     */
+    private static String recombineSurrogatePairs(String xml) {
+        List<int[]> references = new ArrayList<>();
+        Matcher matcher = NUMERIC_REFERENCE.matcher(xml);
+        while (matcher.find()) {
+            references.add(new int[] {matcher.start(), matcher.end(), referenceValue(matcher)});
+        }
+
+        StringBuilder out = new StringBuilder(xml.length());
+        int copiedUpTo = 0;
+        for (int i = 0; i + 1 < references.size(); i++) {
+            int[] high = references.get(i);
+            int[] low = references.get(i + 1);
+            boolean adjacent = high[1] == low[0];
+            if (!adjacent || !isHighSurrogate(high[2]) || !isLowSurrogate(low[2])) {
+                continue;
+            }
+            out.append(xml, copiedUpTo, high[0]);
+            out.append("&#")
+                    .append(Character.toCodePoint((char) high[2], (char) low[2]))
+                    .append(';');
+            copiedUpTo = low[1];
+            i++;
+        }
+        out.append(xml, copiedUpTo, xml.length());
+        return out.toString();
+    }
+
+    /**
+     * @return the referenced code point, or -1 when it cannot be one
+     */
+    private static int referenceValue(Matcher matcher) {
+        String decimal = matcher.group(1);
+        try {
+            long value = decimal != null ? Long.parseLong(decimal) : Long.parseLong(matcher.group(2), 16);
+            return value > Character.MAX_CODE_POINT ? -1 : (int) value;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static boolean isHighSurrogate(int cp) {
+        return cp >= Character.MIN_HIGH_SURROGATE && cp <= Character.MAX_HIGH_SURROGATE;
+    }
+
+    private static boolean isLowSurrogate(int cp) {
+        return cp >= Character.MIN_LOW_SURROGATE && cp <= Character.MAX_LOW_SURROGATE;
+    }
+}

--- a/gpx/src/main/java/io/github/glandais/gpx/io/write/GPXFileWriter.java
+++ b/gpx/src/main/java/io/github/glandais/gpx/io/write/GPXFileWriter.java
@@ -182,16 +182,29 @@ public class GPXFileWriter implements FileExporter {
 
     public static String escape(String s) {
         StringBuilder out = new StringBuilder(Math.max(16, s.length()));
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (c > 127 || c == '"' || c == '\'' || c == '<' || c == '>' || c == '&') {
-                out.append("&#");
-                out.append((int) c);
-                out.append(';');
-            } else {
-                out.append(c);
+        s.codePoints().forEach(cp -> {
+            if (!isXmlChar(cp)) {
+                return;
             }
-        }
+            if (cp > 127 || cp == '"' || cp == '\'' || cp == '<' || cp == '>' || cp == '&') {
+                out.append("&#").append(cp).append(';');
+            } else {
+                out.append((char) cp);
+            }
+        });
         return out.toString();
+    }
+
+    /**
+     * The XML 1.0 Char production. Excludes control characters, lone surrogates and the two
+     * noncharacters, none of which a character reference can express.
+     */
+    private static boolean isXmlChar(int cp) {
+        return cp == 0x9
+                || cp == 0xA
+                || cp == 0xD
+                || (cp >= 0x20 && cp <= 0xD7FF)
+                || (cp >= 0xE000 && cp <= 0xFFFD)
+                || (cp >= 0x10000 && cp <= 0x10FFFF);
     }
 }

--- a/gpx/src/test/java/io/github/glandais/gpx/io/RoundTripTest.java
+++ b/gpx/src/test/java/io/github/glandais/gpx/io/RoundTripTest.java
@@ -1,0 +1,99 @@
+package io.github.glandais.gpx.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.glandais.gpx.data.GPX;
+import io.github.glandais.gpx.data.GPXPath;
+import io.github.glandais.gpx.data.GPXPathType;
+import io.github.glandais.gpx.data.Point;
+import io.github.glandais.gpx.io.read.GPXFileReader;
+import io.github.glandais.gpx.io.write.GPXFileWriter;
+import java.io.File;
+import java.time.Instant;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+class RoundTripTest {
+
+    /** computeArrays() needs an instant on every point, exactly as the reader sets one. */
+    private static Point point(double latDeg, double lonDeg, double ele) {
+        Point p = new Point();
+        p.setLat(Math.toRadians(latDeg));
+        p.setLon(Math.toRadians(lonDeg));
+        p.setEle(ele);
+        p.setInstant(null, Instant.EPOCH);
+        return p;
+    }
+
+    private static File write(GPX gpx, String prefix) throws Exception {
+        File target = File.createTempFile(prefix, ".gpx");
+        target.deleteOnExit();
+        new GPXFileWriter().writeGPX(gpx, target);
+        return target;
+    }
+
+    /**
+     * The emoji is the whole point: escape() used to write it as two surrogate references, so a file
+     * this library produced could not be read back by this library.
+     */
+    @Test
+    void writtenGpxShouldBeReadableBack() throws Exception {
+        GPXPath path = new GPXPath("Sortie 🤘 à Bertaudière", GPXPathType.TRACK);
+        path.addPoint(point(45.1, 6.4, 1200.0));
+        path.addPoint(point(45.2, 6.5, 1300.0));
+        path.computeArrays();
+        GPX original = new GPX("Col du Galibier 🤘", List.of(path), List.of());
+
+        GPX reread = new GPXFileReader().parseGPX(write(original, "roundtrip"));
+
+        assertEquals(original.name(), reread.name());
+        assertEquals(1, reread.paths().size());
+        assertEquals(path.getName(), reread.paths().get(0).getName());
+        assertEquals(2, reread.paths().get(0).getPoints().size());
+    }
+
+    /**
+     * The round trip alone cannot police the writer: the reader repairs surrogate-pair references,
+     * so a broken writer still survives it. Parse the output with a stock parser instead, which
+     * grants no such mercy, and assert what we actually care about — the file we emit is valid XML.
+     */
+    @Test
+    void writtenGpxShouldBeWellFormedXmlWithoutAnyRepair() throws Exception {
+        GPXPath path = new GPXPath("Sortie 🤘", GPXPathType.TRACK);
+        path.addPoint(point(45.1, 6.4, 1200.0));
+        path.addPoint(point(45.2, 6.5, 1300.0));
+        path.computeArrays();
+        GPX original = new GPX("Col 🤘", List.of(path), List.of());
+
+        File target = write(original, "roundtrip-wellformed");
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        Document document = dbf.newDocumentBuilder().parse(target);
+
+        assertEquals("gpx", document.getDocumentElement().getTagName());
+    }
+
+    /** Elevation is written with a single decimal, so the round trip is lossy by construction. */
+    @Test
+    void writtenGpxShouldPreserveCoordinatesWithinWriterPrecision() throws Exception {
+        GPXPath path = new GPXPath("precision", GPXPathType.TRACK);
+        path.addPoint(point(45.1234567, 6.7654321, 1234.56));
+        path.addPoint(point(45.2, 6.5, 1300.0));
+        path.computeArrays();
+        GPX original = new GPX("precision", List.of(path), List.of());
+
+        Point p = new GPXFileReader()
+                .parseGPX(write(original, "roundtrip-precision"))
+                .paths()
+                .get(0)
+                .getPoints()
+                .get(0);
+
+        assertEquals(45.1234567, p.getLatDeg(), 1e-6);
+        assertEquals(6.7654321, p.getLonDeg(), 1e-6);
+        assertEquals(1234.56, p.getEle(), 0.05);
+    }
+}

--- a/gpx/src/test/java/io/github/glandais/gpx/io/read/GPXFileReaderRepairTest.java
+++ b/gpx/src/test/java/io/github/glandais/gpx/io/read/GPXFileReaderRepairTest.java
@@ -1,0 +1,96 @@
+package io.github.glandais.gpx.io.read;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.glandais.gpx.data.GPX;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Test;
+
+class GPXFileReaderRepairTest {
+
+    private static final String SECRET = "top-secret-xxe-marker";
+
+    private static final String TRACK = "<trkseg>"
+            + "<trkpt lat=\"1.0\" lon=\"2.0\"><ele>10</ele></trkpt>"
+            + "<trkpt lat=\"1.1\" lon=\"2.1\"><ele>11</ele></trkpt>"
+            + "</trkseg>";
+
+    private static String gpx(String declaration, String doctype, String trackName) {
+        return declaration
+                + doctype
+                + "<gpx version=\"1.1\" creator=\"test\" xmlns=\"http://www.topografix.com/GPX/1/1\">"
+                + "<trk><name>"
+                + trackName
+                + "</name>"
+                + TRACK
+                + "</trk>"
+                + "</gpx>";
+    }
+
+    private static GPX parse(String xml, Charset charset) throws Exception {
+        return new GPXFileReader().parseGPX(new ByteArrayInputStream(xml.getBytes(charset)));
+    }
+
+    /** Exactly what the old escape() wrote: 26 files of the reference corpus look like this. */
+    @Test
+    void parseGPX_shouldRecoverSurrogatePairReferences() throws Exception {
+        GPX gpx = parse(gpx("<?xml version=\"1.0\"?>", "", "Sortie &#55358;&#56600;"), StandardCharsets.UTF_8);
+
+        assertEquals("Sortie 🤘", gpx.paths().get(0).getName());
+    }
+
+    @Test
+    void parseGPX_shouldRecoverUndeclaredLatin1() throws Exception {
+        GPX gpx = parse(gpx("<?xml version=\"1.0\"?>", "", "Bertaudière"), StandardCharsets.ISO_8859_1);
+
+        assertEquals("Bertaudière", gpx.paths().get(0).getName());
+    }
+
+    /** A healthy file must still travel the strict path, untouched by any repair. */
+    @Test
+    void parseGPX_shouldStillReadValidFile() throws Exception {
+        GPX gpx = parse(gpx("<?xml version=\"1.0\"?>", "", "Galibier"), StandardCharsets.UTF_8);
+
+        assertEquals("Galibier", gpx.paths().get(0).getName());
+        assertEquals(2, gpx.paths().get(0).getPoints().size());
+    }
+
+    /** A real negative fixture: it lives in the tribly project and must stay rejected. */
+    @Test
+    void parseGPX_shouldStillRejectGarbage() {
+        assertThrows(Exception.class, () -> parse("NOT VALID XML CONTENT\n", StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Security regression: a file that is both XXE and latin-1 triggers the repair, hence a second
+     * parsing pass. That pass must stay hardened.
+     */
+    @Test
+    void parseGPX_shouldStillRejectXxeEvenWhenRepairTriggers() throws IOException {
+        File secret = File.createTempFile("xxe-secret", ".txt");
+        secret.deleteOnExit();
+        Files.writeString(secret.toPath(), SECRET);
+
+        String doctype = "<!DOCTYPE gpx [<!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\">]>";
+        String xml = gpx("<?xml version=\"1.0\"?>", doctype, "Bertaudière&xxe;");
+
+        Exception thrown = assertThrows(Exception.class, () -> parse(xml, StandardCharsets.ISO_8859_1));
+
+        assertFalse(stackTrace(thrown).contains(SECRET), "external entity resolved after repair");
+    }
+
+    private static String stackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/gpx/src/test/java/io/github/glandais/gpx/io/read/GpxXmlRepairTest.java
+++ b/gpx/src/test/java/io/github/glandais/gpx/io/read/GpxXmlRepairTest.java
@@ -1,0 +1,70 @@
+package io.github.glandais.gpx.io.read;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class GpxXmlRepairTest {
+
+    private static String repaired(String source, Charset charset) {
+        byte[] out = GpxXmlRepair.repair(source.getBytes(charset));
+        return out == null ? null : new String(out, StandardCharsets.UTF_8);
+    }
+
+    /** Nothing to repair: the reader must rethrow the original error rather than retry. */
+    @Test
+    void repair_shouldReturnNullWhenNothingToFix() {
+        assertNull(repaired("<gpx><trk><name>Galibier</name></trk></gpx>", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void repair_shouldRecombineDecimalSurrogatePair() {
+        assertEquals("<name>&#129304;</name>", repaired("<name>&#55358;&#56600;</name>", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void repair_shouldRecombineHexSurrogatePair() {
+        assertEquals("<name>&#129304;</name>", repaired("<name>&#xD83E;&#xDD18;</name>", StandardCharsets.UTF_8));
+    }
+
+    /** The first reference is not a high surrogate: the real pair follows and must still be seen. */
+    @Test
+    void repair_shouldNotBeConfusedByAPrecedingReference() {
+        assertEquals(
+                "<name>&#65;&#129304;</name>", repaired("<name>&#65;&#55358;&#56600;</name>", StandardCharsets.UTF_8));
+    }
+
+    /** A lone surrogate stays invalid: leave it, so parsing fails and the original error surfaces. */
+    @Test
+    void repair_shouldLeaveLoneSurrogateAlone() {
+        assertNull(repaired("<name>&#55358;</name>", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void repair_shouldLeaveOrdinaryReferencesAlone() {
+        assertNull(repaired("<name>&#232;&#233;</name>", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void repair_shouldDecodeUndeclaredLatin1() {
+        String out = repaired("<?xml version=\"1.0\"?><name>Bertaudière</name>", StandardCharsets.ISO_8859_1);
+        assertEquals("<?xml version=\"1.0\"?><name>Bertaudière</name>", out);
+    }
+
+    /** Re-encoding to UTF-8 without fixing the declaration would produce mojibake. */
+    @Test
+    void repair_shouldRewriteDeclaredEncodingWhenReEncoding() {
+        String out = repaired(
+                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><name>Bertaudière&#55358;&#56600;</name>",
+                StandardCharsets.ISO_8859_1);
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><name>Bertaudière&#129304;</name>", out);
+    }
+
+    @Test
+    void repair_shouldHandleAbsurdlyLargeReferenceWithoutCrashing() {
+        assertNull(repaired("<name>&#999999999999;</name>", StandardCharsets.UTF_8));
+    }
+}

--- a/gpx/src/test/java/io/github/glandais/gpx/io/write/GPXFileWriterEscapeTest.java
+++ b/gpx/src/test/java/io/github/glandais/gpx/io/write/GPXFileWriterEscapeTest.java
@@ -1,0 +1,41 @@
+package io.github.glandais.gpx.io.write;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class GPXFileWriterEscapeTest {
+
+    /** U+1F918 takes two UTF-16 code units: the old code emitted &#55358;&#56600;, which XML forbids. */
+    @Test
+    void escape_shouldEmitOneReferencePerCodePoint() {
+        assertEquals("&#129304;", GPXFileWriter.escape("🤘"));
+    }
+
+    @Test
+    void escape_shouldEscapeNonAsciiAndXmlSpecials() {
+        assertEquals("&#232;", GPXFileWriter.escape("è"));
+        assertEquals("a&#38;b", GPXFileWriter.escape("a&b"));
+        assertEquals("&#60;&#62;&#34;&#39;", GPXFileWriter.escape("<>\"'"));
+    }
+
+    @Test
+    void escape_shouldKeepPlainAsciiAndAllowedWhitespace() {
+        assertEquals("Col du Galibier", GPXFileWriter.escape("Col du Galibier"));
+        assertEquals("a\tb\nc", GPXFileWriter.escape("a\tb\nc"));
+    }
+
+    /** Forbidden by the XML 1.0 Char production: drop them instead of emitting &#1;. */
+    @Test
+    void escape_shouldDropCharactersForbiddenByXml() {
+        assertEquals("ab", GPXFileWriter.escape("a\u0001b"));
+        assertEquals("ab", GPXFileWriter.escape("a\u000Bb"));
+        assertEquals("ab", GPXFileWriter.escape("a\uFFFEb"));
+    }
+
+    /** A lone surrogate forms no character at all, so it must produce nothing. */
+    @Test
+    void escape_shouldDropLoneSurrogate() {
+        assertEquals("ab", GPXFileWriter.escape("a\uD83Eb"));
+    }
+}


### PR DESCRIPTION
## Summary

- `GPXFileWriter.escape()` iterated over UTF-16 code units, so an emoji was written as two numeric references to surrogate code points (`&#55358;&#56600;`), which XML 1.0 forbids. Control characters produced `&#1;`, equally invalid. The `creator` attribute of the affected files matches this library's own `TAG_GPX`: **it was producing GPX it could not parse.** Fixed by iterating code points and dropping characters outside the XML 1.0 `Char` production.
- Recover the files already written, plus old exports encoded in ISO-8859-1 without declaring it. `GPXFileReader` parses strictly first, and only on XML failure retries **once** on bytes repaired by the new `GpxXmlRepair`, through the **same hardened `DocumentBuilder`**. A DOCTYPE is still refused on the second pass, so XXE stays rejected. When repair does not help, the original error reaches the caller.
- Unifying the input on `byte[]` removes the `BiFunction` that only existed to distinguish `File` from `InputStream`.

## Behaviour change

XML errors from `parseGPX(InputStream)` are no longer wrapped in `RuntimeException`; the `SAXParseException` surfaces directly. No signature changes — both overloads already declared `throws Exception`. All modules (`gpx`, `cli`, `web`) build and pass.

## Test Plan

- [x] `mvn test` — 101 tests, all modules green
- [x] `mvn spotless:check` — clean
- [x] Security: `GPXFileReaderXxeTest` still green; new test covers a file that is **both XXE and latin-1**, so repair triggers and the second parse must stay hardened
- [x] Mutation-verified: reverting `escape()` makes `writtenGpxShouldBeWellFormedXmlWithoutAnyRepair` fail. The round trip alone cannot police the writer, since the reader now repairs what it breaks — so `RoundTripTest` also parses the written file with a stock parser
- [x] Verified against **22174 real GPX files (3.8 GB)**:
  - readable files: **22099 → 22165** (66 paths recovered)
  - **0** existing fingerprints changed
  - **22165 / 22165** survive a write-then-read-back round trip
  - the 9 paths still rejected are out of scope by design: bare `&`, concatenated documents, a truncated file, and a negative test fixture that must stay rejected

## Known, left out of scope

`writeGPX(GPX, File)` uses `new FileWriter(target)`, i.e. the platform default encoding, while the header declares UTF-8. Harmless today only because `escape()` emits pure ASCII — the protection is accidental, not intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)